### PR TITLE
Modification to use websockets instead of TCP to connect to the server

### DIFF
--- a/test-messages.py
+++ b/test-messages.py
@@ -12,7 +12,7 @@ import paho.mqtt.client as mqtt
 timestamp = int(time.time())
 
 broker = "127.0.0.1"
-port = 1883
+port = 9001
 element = "home"
 areas = ["front", "back", "kitchen", "basement", "living"]
 entrances = ["door", "window"]
@@ -29,7 +29,7 @@ while True:
         topic = element + "/" + area + "/" + random.choice(entrances)
         message = random.choice(states)
 
-    mqtt_client = mqtt.Client("mqtt-panel-test", protocol=mqtt.MQTTv311)
+    mqtt_client = mqtt.Client("mqtt-panel-test", transport='websockets')
     mqtt_client.connect(broker, port=int(port))
     mqtt_client.publish(topic, message)
     time.sleep(2)


### PR DESCRIPTION
This modification was needed to use your python script on my Mosquitto server, configured to use websockets instead of MQTT protocol to use when listening.

So now the Python script and the web panel works! 

Thanks you very much for your work :-)